### PR TITLE
Add i18n module example

### DIFF
--- a/packages/i18n-package/i18n-intercept.js
+++ b/packages/i18n-package/i18n-intercept.js
@@ -1,0 +1,7 @@
+module.exports = targets => {
+    const builtins = targets.of('@magento/pwa-buildpack');
+
+    builtins.specialFeatures.tap(features => {
+        features[targets.name] = { i18n: true };
+    });
+}

--- a/packages/i18n-package/i18n/en_US.json
+++ b/packages/i18n-package/i18n/en_US.json
@@ -1,0 +1,3 @@
+{
+    "Live Chat": "Live Chat Override"
+}

--- a/packages/i18n-package/package.json
+++ b/packages/i18n-package/package.json
@@ -1,0 +1,20 @@
+{
+    "name": "@magento-research/i18n-package",
+    "version": "0.0.1",
+    "description": "Provide translations for PWA Studio",
+    "publishConfig": {
+      "access": "public"
+    },
+    "license": "(OSL-3.0 OR AFL-3.0)",
+    "main": "./i18n-intercept.js",
+    "repository": "github:magento-research/pwa-studio-target-experiments",
+    "peerDependencies": {
+      "@magento/pwa-buildpack": "^5.1.1",
+      "@magento/venia-ui": "^3.0.0"
+    },
+    "pwa-studio": {
+      "targets": {
+        "intercept": "./i18n-intercept"
+    }
+  }
+}


### PR DESCRIPTION
Closed in favor of: https://github.com/magento/pwa-studio/tree/develop/packages/extensions/venia-sample-language-packs